### PR TITLE
Add limited service definitions

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -36,6 +36,7 @@ def __go_client():
         "name": "go-client",
         "steps": [
             __step_proto("go", "v1alpha1/types", ["go_out", "go-grpc_out"]),
+            __step_proto("go", "v1alpha1/services", ["go_out", "go-grpc_out"]),
 
             # Todo: Publish to GitHub branch
         ]
@@ -52,7 +53,8 @@ def __ruby_client():
         "name": "ruby-client",
         "steps": [
             __step_proto("ruby", "v1alpha1/types", ["ruby_out"]),
-
+            __step_proto("ruby", "v1alpha1/services", ["ruby_out"]),
+            
             # Todo: Publish to GitHub Package Store
         ]
     }
@@ -68,6 +70,7 @@ def __js_client():
         "name": "js-client",
         "steps": [
             __step_proto("js", "v1alpha1/types", ["js_out"]),
+            __step_proto("js", "v1alpha1/services", ["js_out"]),
 
             # Todo: Publish to GitHub Package Store
         ]
@@ -84,6 +87,7 @@ def __java_client():
         "name": "java-client",
         "steps": [
             __step_proto("java", "v1alpha1/types", ["java_out"]),
+            __step_proto("java", "v1alpha1/services", ["java_out"]),
 
             # Todo: Publish to GitHub Package Store
         ]
@@ -109,7 +113,7 @@ def __step_proto(name, src, plugins):
 
     # Compile the step
     return  {
-        "name": name,
+        "name": "%s: %s" % (name, src),
         "image": "littleman/proto:latest",
         "commands": [
             "mkdir -p %s" % dest,

--- a/v1alpha1/services/incident.proto
+++ b/v1alpha1/services/incident.proto
@@ -1,0 +1,72 @@
+//https://cloud.google.com/apis/design/standard_methods#get
+syntax = "proto3";
+
+package v1alpha1.services;
+
+import "v1alpha1/types/incident.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+
+option go_package = "github.com/ahshtio/apis/v1alpha1/services";
+
+service Incident {
+	rpc GetIncident(GetIncidentRequest) returns (v1alpha1.types.Incident) {
+    }
+
+    rpc GetIncidents(GetIncidentsRequest) returns (GetIncidentsResponse) {
+    }
+
+	rpc PutIncident(PutIncidentRequest) returns (google.protobuf.Empty) {
+    }
+
+    rpc DeleteIncident(DeleteIncidentRequest) returns (google.protobuf.Empty) {
+    }
+
+    rpc UpdateIncident(UpdateIncidentRequest) returns (google.protobuf.Empty) {
+    }
+    
+    // Todo: Should this be a sort of, "meta event" indicating change information?
+    rpc WatchIncidents(WatchIncidentRequest) returns (stream WatchIncidentResponse) {
+    }
+}
+
+message GetIncidentRequest {
+    // see types.Incident.id
+	string id = 1;
+}
+
+message GetIncidentsRequest {
+    // see types.Incident
+    v1alpha1.types.Incident incident = 1;
+
+    google.protobuf.FieldMask mask = 2;
+}
+
+message GetIncidentsResponse {
+    repeated v1alpha1.types.Incident incidents = 1;
+}
+
+message PutIncidentRequest {
+    // see types.Incident
+    v1alpha1.types.Incident incident = 1;
+}
+
+message DeleteIncidentRequest {
+    // see types.Incident.id
+    string id = 1;
+}
+
+message UpdateIncidentRequest {
+    // see types.Incident
+    v1alpha1.types.Incident incident = 1;
+
+    google.protobuf.FieldMask mask = 2;
+}
+
+message WatchIncidentRequest {
+}
+
+message WatchIncidentResponse {
+    // see types.Incident
+    v1alpha1.types.Incident incident = 1;
+}


### PR DESCRIPTION
This commit introduces some extremely basic service defintions,
similarly to CRUD style definitions.

== Design Notes
=== Requests as messages

Each RPC has a specific input parameter which takes a set of input
messages.

This follows the pattern defined at:

https://cloud.google.com/apis/design/standard_methods#update

It is a little unusual, however the author will retain it as they do not
know as much as the authors of that content.

== Chosen Methods

The methods were chosen for their ability to fulfil a set of anticipated
use cases, such as:

- Get
- Set
- Update
- Watch
- Search

Which tend to be the common user patterns for this sort of data.