### PR TITLE
Generate the Go library whenever master is changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.drone.yml


### PR DESCRIPTION
Currently the go library is generated, but not published anyhere.

This commit addresses that by publishing it to a specific `go` branch.

In this way, the go mod packaging system can find, and keep track of it
like a normal git branch. Additionally, the import paths look nice.

== Design Notes
=== Complex Build

Ths requires some considerable complexity with the build process. Future
work should seek to refactor this.