### PR TITLE
Fix the layout of files

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -32,8 +32,7 @@ def __go_client():
         "kind": "pipeline",
         "name": "go-client",
         "steps": [
-            __step_proto("go", "v1alpha1/types", ["go_out", "go-grpc_out"]),
-            __step_proto("go", "v1alpha1/services", ["go_out", "go-grpc_out"]),
+            __step_proto("go", "incident/v1alpha1", ["go_out", "go-grpc_out"]),
             {
                 "name": "publish",
                 "image": "alpine/git",

--- a/incident/v1alpha1/service.proto
+++ b/incident/v1alpha1/service.proto
@@ -1,16 +1,16 @@
 //https://cloud.google.com/apis/design/standard_methods#get
 syntax = "proto3";
 
-package v1alpha1.services;
+package v1alpha1;
 
-import "v1alpha1/types/incident.proto";
+import "incident/v1alpha1/types.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 
-option go_package = "github.com/ahshtio/apis/v1alpha1/services";
+option go_package = "github.com/ahshtio/apis/incident/v1alpha1";
 
-service Incident {
-	rpc GetIncident(GetIncidentRequest) returns (v1alpha1.types.Incident) {
+service IncidentService {
+	rpc GetIncident(GetIncidentRequest) returns (Incident) {
     }
 
     rpc GetIncidents(GetIncidentsRequest) returns (GetIncidentsResponse) {
@@ -37,18 +37,18 @@ message GetIncidentRequest {
 
 message GetIncidentsRequest {
     // see types.Incident
-    v1alpha1.types.Incident incident = 1;
+    v1alpha1.Incident incident = 1;
 
     google.protobuf.FieldMask mask = 2;
 }
 
 message GetIncidentsResponse {
-    repeated v1alpha1.types.Incident incidents = 1;
+    repeated v1alpha1.Incident incidents = 1;
 }
 
 message PutIncidentRequest {
     // see types.Incident
-    v1alpha1.types.Incident incident = 1;
+    v1alpha1.Incident incident = 1;
 }
 
 message DeleteIncidentRequest {
@@ -58,7 +58,7 @@ message DeleteIncidentRequest {
 
 message UpdateIncidentRequest {
     // see types.Incident
-    v1alpha1.types.Incident incident = 1;
+    v1alpha1.Incident incident = 1;
 
     google.protobuf.FieldMask mask = 2;
 }
@@ -68,5 +68,5 @@ message WatchIncidentRequest {
 
 message WatchIncidentResponse {
     // see types.Incident
-    v1alpha1.types.Incident incident = 1;
+    v1alpha1.Incident incident = 1;
 }

--- a/incident/v1alpha1/types.proto
+++ b/incident/v1alpha1/types.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package v1alpha1.types;
+package v1alpha1;
 
 option go_package = "github.com/ahshtio/apis/v1alpha1/types";
 


### PR DESCRIPTION
In:

  https://github.com/littlemanco/oilr--proj/issues/2

It was decided that the correct way to layout protobuf definitions was
to lay them out similarly to how Googleapis does it:

  https://github.com/googleapis/googleapis

This was chosen largely as it is just the "expected" path to do so.

BREAKING CHANGE:
  - Modifies import paths et. al for all packages, languages.