### PR TITLE
Extend the the timeline with a "free text" field

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -32,7 +32,7 @@ def __go_client():
         "kind": "pipeline",
         "name": "go-client",
         "steps": [
-            __step_proto("go", "incident/v1alpha2", ["go_out", "go-grpc_out"]),
+            __step_proto("go", "incident/v1alpha3", ["go_out", "go-grpc_out"]),
             {
                 "name": "publish",
                 "image": "alpine/git",

--- a/incident/v1alpha3/service.proto
+++ b/incident/v1alpha3/service.proto
@@ -1,13 +1,13 @@
 //https://cloud.google.com/apis/design/standard_methods#get
 syntax = "proto3";
 
-package v1alpha2;
+package v1alpha3;
 
-import "incident/v1alpha2/types.proto";
+import "incident/v1alpha3/types.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 
-option go_package = "github.com/ahshtio/apis/incident/v1alpha2";
+option go_package = "github.com/ahshtio/apis/incident/v1alpha3";
 
 // IncidentService is the primary way to interact with incidents managed by the platform.
 service IncidentService {
@@ -51,18 +51,18 @@ message GetIncidentRequest {
 
 message GetIncidentsRequest {
     // see types.Incident
-    v1alpha2.Incident incident = 1;
+    v1alpha3.Incident incident = 1;
 
     google.protobuf.FieldMask mask = 2;
 }
 
 message GetIncidentsResponse {
-    repeated v1alpha2.Incident incidents = 1;
+    repeated v1alpha3.Incident incidents = 1;
 }
 
 message PutIncidentRequest {
     // see types.Incident
-    v1alpha2.Incident incident = 1;
+    v1alpha3.Incident incident = 1;
 }
 
 message DeleteIncidentRequest {
@@ -72,7 +72,7 @@ message DeleteIncidentRequest {
 
 message UpdateIncidentRequest {
     // see types.Incident
-    v1alpha2.Incident incident = 1;
+    v1alpha3.Incident incident = 1;
 
     google.protobuf.FieldMask mask = 2;
 }
@@ -82,7 +82,7 @@ message WatchIncidentRequest {
 
 message WatchIncidentResponse {
     // see types.Incident
-    v1alpha2.Incident incident = 1;
+    v1alpha3.Incident incident = 1;
 }
 
 // AddEventRequest contains the content required to complete the "IncidentService.AddEvent" RPC
@@ -93,5 +93,5 @@ message AddEventRequest {
 	// Example: e1da1be2-eff2-11e8-a204-0f0dc88152cb
     string incident_id = 1;
 
-    v1alpha2.Event event = 2;
+    v1alpha3.Event event = 2;
 }

--- a/incident/v1alpha3/types.proto
+++ b/incident/v1alpha3/types.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package v1alpha2;
+package v1alpha3;
 
-option go_package = "github.com/ahshtio/apis/incident/v1alpha2";
+option go_package = "github.com/ahshtio/apis/incident/v1alpha3";
 
 import "google/protobuf/timestamp.proto";
 
@@ -48,8 +48,24 @@ message Event {
     google.protobuf.Timestamp timestamp = 2;
 
     // A free text description of a given event.
-    string description = 3;
+    Text description = 3;
 
     // A set of free tags associated this event to group and categories timeline entries.
     repeated string tags = 4;
+}
+
+// "Text" is a field type which is essentially a "free text" field, flavoured with a particular markup type.
+message Text {
+    // The "Syntax" is the tooling that should be used to convert the content to a consumable format.
+    enum Syntax {
+        PLAIN_TEXT = 0;
+        MARKDOWN = 1;
+        ASCIIDOC = 2;
+    }
+
+    // The syntax used in this text area
+    Syntax syntax = 1;
+
+    // The content of this text area
+    string content = 2;
 }


### PR DESCRIPTION
Broadly, each timeline event might have references to other systems to
it — whether that's time series data systems, log systems etc.

Capturing these links to other systems is useful, as we can then reuse
these links in other display formats. However, figuring out how to store
the link is not trivial.

Rather than answer that question, this commit takes a different approach
— it allows the user to just store that (and other rich text
information) in a format of their choosing, within the text field.

These can be fairly easily tokenized and the links extracted as
required, but provides a familiar design for consumers and implementers
to reason through this content.

== Design Notes
=== Alternative: Reference style + links

The author started with an initial style which was the "referenence"
style. The message was structured:

[source,proto]
----
message Event {
    ...
    string description = 3;

    message Link {
        int id = 1;

        int URL = 2;
    }

    repeated Link links = 4;
}
----

However, figuring out the "id" to use was not trivial, and this design
requires some tokenizing of the text that ... doesn't feel natural.

BREAKING CHANGE: This breaks the v1alpha1 BC guarantee. Given this, the
                 minor version has been bumped.